### PR TITLE
[SPRINT_TASK-27285] Fix clockwork for checkout and asset loads

### DIFF
--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -64,6 +64,10 @@ Clockwork.controller('PanelController', function($scope, $http, toolbar)
 					baseUrl = $scope.baseUrl
 				}
 				var uri = new URI(baseUrl);
+
+				uri.subdomain(uri.subdomain().replace(/\.checkout$/, '')); // Handle checkout pages
+				uri.subdomain(uri.subdomain().replace(/^assets-/, '')); // Handle asset loads
+
 				var path = ((requestPath) ? requestPath.value : '/__clockwork/') + requestId.value;
 
 				path = path.split('?');


### PR DESCRIPTION
@duhruh @mattdeclaire @sroussey

This strips out checkout and assets from the url when building a clockwork request.
